### PR TITLE
Add skip for setup/teardown module

### DIFF
--- a/madforhooks/check_test_naming.py
+++ b/madforhooks/check_test_naming.py
@@ -50,7 +50,8 @@ def is_misnamed_test_func(
         and not any(_is_fixture(decorator) for decorator in node.decorator_list)
         and PRAGMA not in line
         and node.name
-        not in ("teardown_method", "setup_method", "teardown_class", "setup_class")
+        not in ("teardown_method", "setup_method", "teardown_class", "setup_class",
+                "teardown_module", "setup_module")
     )
 
 

--- a/madforhooks/check_test_naming.py
+++ b/madforhooks/check_test_naming.py
@@ -50,8 +50,14 @@ def is_misnamed_test_func(
         and not any(_is_fixture(decorator) for decorator in node.decorator_list)
         and PRAGMA not in line
         and node.name
-        not in ("teardown_method", "setup_method", "teardown_class", "setup_class",
-                "teardown_module", "setup_module")
+        not in (
+            "teardown_method",
+            "setup_method",
+            "teardown_class",
+            "setup_class",
+            "teardown_module",
+            "setup_module",
+        )
     )
 
 


### PR DESCRIPTION
Minor improvement from testing this in the wild. Adds a skip for `{setup,teardown}_module` as per https://docs.pytest.org/en/6.2.x/xunit_setup.html#module-level-setup-teardown